### PR TITLE
Update url to use angpaul2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A project based learning activity for people who are getting started with Git and GitHub.
 
-You can play the game at: http://githubschool.github.io/github-games/
+You can play the game at: http://angpaul2.github.io/github-games/
 
 >> _*SUPPORTED BROWSERS*: Chrome, Firefox, Safari, Opera and IE9+_
 


### PR DESCRIPTION
This PR updates the url to point to angpaul2 instead of githubschool
